### PR TITLE
chore: update or:url to use alt_seo_meta_url from context

### DIFF
--- a/src/Tags/AltSeo.php
+++ b/src/Tags/AltSeo.php
@@ -48,7 +48,7 @@ class AltSeo extends Tags
         $returnString = '<title>' . $this->getTitle() . '</title>';
         $returnString .= '<meta name="description" content="' . strip_tags($this->getDescription()) . '" />';
         $returnString .= '<!-- Facebook Meta Tags -->';
-        $returnString .= '<meta property="og:url" content="' . ENV('APP_URL') . '">';
+        $returnString .= '<meta property="og:url" content="' . $this->getUrl() . '">';
         $returnString .= '<meta property="og:type" content="website">';
         $returnString .= '<meta property="og:title" content="' . $this->getSocialTitle() . '">';
         $returnString .= '<meta property="og:description" content="' . strip_tags($this->getSocialDescription()) . '">';
@@ -117,6 +117,20 @@ class AltSeo extends Tags
         }
 
         return '';
+    }
+
+    /**
+     * Bring the url in and return the correct instance.
+     *
+     * @return mixed|string
+     */
+    public function getUrl()
+    {
+        if(!empty($this->context->value('alt_seo_meta_url'))) {
+            return Antlers::parse($this->replaceVars($this->context->value('alt_seo_meta_url')));
+        }
+
+        return ENV('APP_URL');
     }
 
     /**


### PR DESCRIPTION

As [Basic Metadata](https://ogp.me/#:~:text=og%3Aurl%20%2D%20The%20canonical%20URL%20of%20your%20object%20that%20will%20be%20used%20as%20its%20permanent%20ID%20in%20the%20graph%2C%20e.g.%2C%20%22https%3A//www.imdb.com/title/tt0117500/%22) example

> og:url - The canonical URL of your object that will be used as its permanent ID in the graph, e.g., 
> "https://www.imdb.com/title/tt0117500/".

I added `alt_seo_meta_url` to the context , so the user can use it as following and if it is empty, it will use the APP_URL as default

```yaml
id: 76d67bea-e79c-4ad0-adc9-774966702225
blueprint: article
layout: doc
title: 'Exploring MySQL Command to Retrieve All Columns of All Tables with Available Options'
date: 1692921600
author: 'Muath Alsowadi'
gravatar: 19684bc9c928dffa64f9c23efb31ba86
twitter: '@muathye'
alt_seo_meta_description: 'Explore the versatile MySQL command to retrieve comprehensive column information from all tables in your database, with options to sort, filter by data type, and exclude system tables.'
alt_seo_social_description: 'Explore the versatile MySQL command to retrieve comprehensive column information from all tables in your database, with options to sort, filter by data type, and exclude system tables.'
alt_seo_social_image: 'https://muathye.com/articles/2023-08-25/exploring-mysql-command-to-retrieve-all-columns-of-all-tables-with-available-options.webp'
alt_seo_meta_url: 'https://muathye.com/articles/2023-05-22-how-to-create-a-command-line-password-generator-with-nodejs'
```

