### PR TITLE
Bugfix: Index is not always 6

### DIFF
--- a/src/Events/Seo.php
+++ b/src/Events/Seo.php
@@ -2,7 +2,6 @@
 
 use Statamic\Events;
 use Statamic\Fields\BlueprintRepository;
-use Statamic\Facades\Entry;
 use AltDesign\AltSeo\Helpers\Data;
 
 /**
@@ -63,7 +62,8 @@ class Seo
         if ($data->get('alt_seo_asset_container') !== null)
         {
             $contents = $blueprint->contents();
-            $contents['tabs']['alt_seo']['sections'][0]['fields'][6]['field']['container'] = $data->get('alt_seo_asset_container');
+            $index = array_search('alt_seo_social_image', array_column($contents['tabs']['alt_seo']['sections'][0]['fields'], 'handle'));
+            $contents['tabs']['alt_seo']['sections'][0]['fields'][$index]['field']['container'] = $data->get('alt_seo_asset_container');
             $blueprint->setContents($contents);
         }
 


### PR DESCRIPTION
The index is not always 6; therefore the value gets set on a wrong array. This code prevents that using `array_search` so the key always matches `alt_seo_social_image`