### PR TITLE
Refactored Meta templating

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,38 @@ You can use variables such as {title} | {site_name}
 
 App name and url are taken from .env file so ensure this data is correct. Images must be stored in assets container.
 
+## Advanced usage
+
+### Overriding Meta Fields
+
+All fields handled by the addon are wrapped so that that they can be overridden in your templates.
+
+Let's say, for example, you had a product page that you wanted to change the meta title structure from default, this can be achieved in your template using the {{ section }} tag
+
+Simply add something along the line of this in your template and the appropriate meta field will get overridden:
+``` bash
+{{ section:alt_seo_title }}Awesome SEO title goes here!!!{{ /section:alt_seo_title }}
+```
+
+Note : Only the data sections of the meta fields are tagged so don't us full tags as that will cause some funky HTML
+
+The fields that can be overridden as list here :
+
+- alt_seo_title
+- alt_seo_canonical
+- alt_seo_description
+- alt_seo_og_url
+- alt_seo_og_type
+- alt_seo_og_title
+- alt_seo_og_description
+- alt_seo_og_image
+- alt_seo_twitter_card
+- alt_seo_twitter_domain
+- alt_seo_twitter_url
+- alt_seo_twitter_title
+- alt_seo_twitter_description
+- alt_seo_twitter_image
+
 ## Questions etc
 
 Drop us a big shout-out if you have any questions, comments, or concerns. We're always looking to improve our addons, so if you have any feature requests, we'd love to hear them.

--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ The fields that can be overridden as list here :
 - alt_seo_title
 - alt_seo_canonical
 - alt_seo_description
+- alt_seo_robots
 - alt_seo_og_url
 - alt_seo_og_type
 - alt_seo_og_title

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -77,17 +77,27 @@ class ServiceProvider extends AddonServiceProvider
     }
 
     /**
+     * Load our views.
+     *
+     * @return void
+     */
+    protected function loadViews()
+    {
+        $this->loadViewsFrom(__DIR__.'/resources/views', 'alt-seo');
+    }
+    
+    /**
      * Statamic boot method.
      *
      * @return void
      */
     public function bootAddon()
     {
+        $this->loadViews();
         $this->addToNav();
         $this->registerPermissions();
         $this->registerEvents();
     }
-
 }
 
 

--- a/src/Tags/AltSeo.php
+++ b/src/Tags/AltSeo.php
@@ -16,7 +16,7 @@ use Statamic\View\Antlers\AntlersString;
  * @license  Copyright (C) Alt Design Limited - All Rights Reserved - licensed under the MIT license
  * @link     https://alt-design.net
  */
-class AltSeo extends Tags
+class AltSeoClone extends Tags
 {
     /**
      * The {{ alt_seo }} tag.
@@ -46,25 +46,30 @@ class AltSeo extends Tags
      */
     public function meta()
     {
-        $returnArray = [];
-        $returnArray[] = '<title>' . $this->getTitle() . '</title>';
-        $returnArray[] = '<link rel="canonical" href="' . $this->getCanonical() . '" />';
-        $returnArray[] = '<meta name="description" content="' . strip_tags($this->getDescription()) . '" />';
-        $returnArray[] = '<!-- Facebook Meta Tags -->';
-        $returnArray[] = '<meta property="og:url" content="' . $this->getCanonical() . '">';
-        $returnArray[] = '<meta property="og:type" content="website">';
-        $returnArray[] = '<meta property="og:title" content="' . $this->getSocialTitle() . '">';
-        $returnArray[] = '<meta property="og:description" content="' . strip_tags($this->getSocialDescription()) . '">';
-        $returnArray[] = '<meta property="og:image" content="' . $this->getSocialImage() . '">';
-        $returnArray[] = '<!-- Twitter Meta Tags -->';
-        $returnArray[] = '<meta name="twitter:card" content="summary_large_image">';
-        $returnArray[] = '<meta property="twitter:domain" content="' . ENV('APP_URL') . '">';
-        $returnArray[] = '<meta property="twitter:url" content="' . $this->getCanonical() . '">';
-        $returnArray[] = '<meta name="twitter:title" content="' . $this->getSocialTitle() . '">';
-        $returnArray[] = '<meta name="twitter:description" content="' . strip_tags($this->getSocialDescription()) . '">';
-        $returnArray[] = '<meta property="twitter:image" content="' . $this->getSocialImage() .'">';
+        return view('alt-seo::meta', $this->meta_array());
+    }
 
-        return implode(PHP_EOL, $returnArray);
+    // Supporting function for the meta() function view
+    private function meta_array()
+    {
+        return [
+            'title' => $this->getTitle(),
+            'canonical' => $this->getCanonical(),
+            'description' => strip_tags($this->getDescription()),
+
+            'og_url' => $this->getCanonical(),
+            'og_type' => 'website',
+            'og_title' => $this->getSocialTitle(),
+            'og_description' => strip_tags($this->getSocialDescription()),
+            'og_image' => $this->getSocialImage(),
+
+            'twitter_card' => 'summary_large_image',
+            'twitter_domain' => ENV('APP_URL'),
+            'twitter_url' => $this->getCanonical(),
+            'twitter_title' => $this->getSocialTitle(),
+            'twitter_description' => strip_tags($this->getSocialDescription()),
+            'twitter_image' => $this->getSocialImage(),
+        ];
     }
 
     /**
@@ -187,7 +192,6 @@ class AltSeo extends Tags
 
         return $socialDescription;
     }
-
 
     /**
      * Bring the social image in and return the correct instance.

--- a/src/Tags/AltSeo.php
+++ b/src/Tags/AltSeo.php
@@ -16,7 +16,7 @@ use Statamic\View\Antlers\AntlersString;
  * @license  Copyright (C) Alt Design Limited - All Rights Reserved - licensed under the MIT license
  * @link     https://alt-design.net
  */
-class AltSeoClone extends Tags
+class AltSeo extends Tags
 {
     /**
      * The {{ alt_seo }} tag.

--- a/src/Tags/AltSeo.php
+++ b/src/Tags/AltSeo.php
@@ -53,11 +53,9 @@ class AltSeo extends Tags
     private function meta_array()
     {
         $metaRobots = [];
-
         if ($this->context->value('alt_seo_noindex')) {
             $metaRobots[] = 'noindex';
         }
-
         if ($this->context->value('alt_seo_nofollow')) {
             $metaRobots[] = 'nofollow';
         }
@@ -66,7 +64,6 @@ class AltSeo extends Tags
             'title' => $this->getTitle(),
             'canonical' => $this->getCanonical(),
             'description' => strip_tags($this->getDescription()),
-
             'robots' => implode(', ', $metaRobots),
 
             'og_url' => $this->getCanonical(),

--- a/src/resources/views/meta.antlers.html
+++ b/src/resources/views/meta.antlers.html
@@ -1,6 +1,7 @@
 <title>{{ yield:alt_seo_title }}{{ title }}{{ /yield:alt_seo_title }}</title>
 <link rel="canonical" href="{{ yield:alt_seo_canonical }}{{ canonical }}{{ /yield:alt_seo_canonical }}">
 <meta name="description" content="{{ yield:alt_seo_description }}{{ description }}{{ /yield:alt_seo_description }}">
+<meta name="robots" content="{{ yield:alt_seo_robots }}{{ robots }}{{ /yield:alt_seo_robots }}">
 <!-- Facebook Meta Tags -->
 <meta property="og:url" content="{{ yield:alt_seo_og_url }}{{ og_url }}{{ /yield:alt_seo_og_url }}">
 <meta property="og:type" content="{{ yield:alt_seo_og_type }}{{ og_type }}{{ /yield:alt_seo_og_type }}">

--- a/src/resources/views/meta.antlers.html
+++ b/src/resources/views/meta.antlers.html
@@ -1,0 +1,16 @@
+<title>{{ yield:alt_seo_title }}{{ title }}{{ /yield:alt_seo_title }}</title>
+<link rel="canonical" href="{{ yield:alt_seo_canonical }}{{ canonical }}{{ /yield:alt_seo_canonical }}">
+<meta name="description" content="{{ yield:alt_seo_description }}{{ description }}{{ /yield:alt_seo_description }}">
+<!-- Facebook Meta Tags -->
+<meta property="og:url" content="{{ yield:alt_seo_og_url }}{{ og_url }}{{ /yield:alt_seo_og_url }}">
+<meta property="og:type" content="{{ yield:alt_seo_og_type }}{{ og_type }}{{ /yield:alt_seo_og_type }}">
+<meta property="og:title" content="{{ yield:alt_seo_og_title }}{{ og_title }}{{ /yield:alt_seo_og_title }}">
+<meta property="og:description" content="{{ yield:alt_seo_og_description }}{{ og_description }}{{ /yield:alt_seo_og_description }}">
+<meta property="og:image" content="{{ yield:alt_seo_og_image }}{{ og_image }}{{ /yield:alt_seo_og_image }}">
+<!-- Twitter Meta Tags -->
+<meta name="twitter:card" content="{{ yield:alt_seo_twitter_card }}{{ twitter_card }}{{ /yield:alt_seo_twitter_card }}">
+<meta name="twitter:domain" content="{{ yield:alt_seo_twitter_domain }}{{ twitter_domain }}{{ /yield:alt_seo_twitter_domain }}">
+<meta property="twitter:url" content="{{ yield:alt_seo_twitter_url }}{{ twitter_url }}{{ /yield:alt_seo_twitter_url }}">
+<meta name="twitter:title" content="{{ yield:alt_seo_twitter_title }}{{ twitter_title }}{{ /yield:alt_seo_twitter_title }}">
+<meta name="twitter:description" content="{{ yield:alt_seo_twitter_description }}{{ twitter_description }}{{ /yield:alt_seo_twitter_description }}">
+<meta name="twitter:image" content="{{ yield:alt_seo_twitter_image }}{{ twitter_image }}{{ /yield:alt_seo_twitter_image }}">


### PR DESCRIPTION
Meta section generation has been redone throughout and shifted to an antlers.html view.

This brings with it a change where all meta fields are now wrapped in {{ yield }} tags which means that {{ section }} tags can be used in templates to override the meta fields in the header. Details of the field names and how to override them is located in the addon readme.