### PR TITLE
Fix for multisite + Fix for social image hosted on other filesystems like s3

### DIFF
--- a/src/Tags/AltSeo.php
+++ b/src/Tags/AltSeo.php
@@ -73,7 +73,7 @@ class AltSeo extends Tags
             'og_image' => $this->getSocialImage(),
 
             'twitter_card' => 'summary_large_image',
-            'twitter_domain' => $this->context->value('site:url'),
+            'twitter_domain' => $this->context->value('site')->url,
             'twitter_url' => $this->getCanonical(),
             'twitter_title' => $this->getSocialTitle(),
             'twitter_description' => strip_tags($this->getSocialDescription()),
@@ -89,7 +89,7 @@ class AltSeo extends Tags
      */
     public function replaceVars($string){
         $blueprintPageTitle = $this->context->value('title'); // Page Title
-        $appName = $this->context->value('site:name'); // App Name
+        $appName = $this->context->value('site')->name; // App Name
         $string = str_replace('{title}', $blueprintPageTitle, $string);
         $string = str_replace('{site_name}', $appName, $string);
         return $string;
@@ -112,7 +112,7 @@ class AltSeo extends Tags
             return $this->replaceVars($title);
         }
 
-        return $this->context->value('title') . ' | ' . $this->context->value('site:name');
+        return $this->context->value('title') . ' | ' . $this->context->value('site')->name;
     }
 
     /**
@@ -168,7 +168,7 @@ class AltSeo extends Tags
             return $this->replaceVars($title);
         }
 
-        return $this->context->value('title') . ' | ' . $this->context->value('site:name');
+        return $this->context->value('title') . ' | ' . $this->context->value('site')->name;
     }
 
     /**
@@ -219,7 +219,7 @@ class AltSeo extends Tags
                 $imageURL = str_replace('/assets/', '', $image);
             }
         }
-        $appUrl = $this->context->value('site:url');
+        $appUrl = $this->context->value('site')->url;
         if(!empty($imageURL) && !str_contains($imageURL, $appUrl)) {
             $imageURL = $appUrl . '/assets/' . $imageURL;
         }

--- a/src/Tags/AltSeo.php
+++ b/src/Tags/AltSeo.php
@@ -73,7 +73,7 @@ class AltSeo extends Tags
             'og_image' => $this->getSocialImage(),
 
             'twitter_card' => 'summary_large_image',
-            'twitter_domain' => config('app.url'),
+            'twitter_domain' => $this->context->value('site:url'),
             'twitter_url' => $this->getCanonical(),
             'twitter_title' => $this->getSocialTitle(),
             'twitter_description' => strip_tags($this->getSocialDescription()),
@@ -89,7 +89,7 @@ class AltSeo extends Tags
      */
     public function replaceVars($string){
         $blueprintPageTitle = $this->context->value('title'); // Page Title
-        $appName = $this->context->value('config.app.name'); // App Name
+        $appName = $this->context->value('site:name'); // App Name
         $string = str_replace('{title}', $blueprintPageTitle, $string);
         $string = str_replace('{site_name}', $appName, $string);
         return $string;
@@ -112,7 +112,7 @@ class AltSeo extends Tags
             return $this->replaceVars($title);
         }
 
-        return $this->context->value('title') . ' | ' . $this->context->value('config.app.name');
+        return $this->context->value('title') . ' | ' . $this->context->value('site:name');
     }
 
     /**
@@ -168,7 +168,7 @@ class AltSeo extends Tags
             return $this->replaceVars($title);
         }
 
-        return $this->context->value('title') . ' | ' . $this->context->value('config.app.name');
+        return $this->context->value('title') . ' | ' . $this->context->value('site:name');
     }
 
     /**
@@ -219,7 +219,7 @@ class AltSeo extends Tags
                 $imageURL = str_replace('/assets/', '', $image);
             }
         }
-        $appUrl = config('app.url');
+        $appUrl = $this->context->value('site:url');
         if(!empty($imageURL) && !str_contains($imageURL, $appUrl)) {
             $imageURL = $appUrl . '/assets/' . $imageURL;
         }

--- a/src/Tags/AltSeo.php
+++ b/src/Tags/AltSeo.php
@@ -229,12 +229,12 @@ class AltSeo extends Tags
             $disk = $assetContainer ? $assetContainer->disk() : null;
             $assetBaseUrl = $assetContainer ? $assetContainer->url() : null;
 
-            if ($disk && $assetBaseUrl && !empty($image)) {
+            if ($disk && $assetBaseUrl && !empty($imageURL)) {
                 // Remove leading slash if present
-                $image = ltrim($image, '/');
-                $imageURL = rtrim($assetBaseUrl, '/') . '/' . $image;
+                $imageURL = ltrim($imageURL, '/');
+                $imageURL = rtrim($assetBaseUrl, '/') . '/' . $imageURL;
             } else {
-                $imageURL = str_replace('/assets/', '', $image);
+                $imageURL = str_replace('/assets/', '', $imageURL);
             }
         }
         

--- a/src/Tags/AltSeo.php
+++ b/src/Tags/AltSeo.php
@@ -221,8 +221,8 @@ class AltSeo extends Tags
         }
 
         // If the image is an absolute URL (e.g., S3), use it as is
-        if (preg_match('/^https?:\/\//', $image)) {
-            $imageURL = $image;
+        if (preg_match('/^https?:\/\//', $imageURL)) {
+            return $imageURL;
         } else {
             // Check if Statamic is configured to use S3 or local assets
             $assetContainer = \Statamic\Facades\AssetContainer::findByHandle('assets');


### PR DESCRIPTION
This PR contains fixes for using Alt SEO in a Statamic multisite.

Basically the site name and URL now come from the site variable (which is the current active site in multisite) and not the config, which is always just one site.